### PR TITLE
update to generate index.htm (as a TOC)

### DIFF
--- a/onenote-powershell-html-export.ps1
+++ b/onenote-powershell-html-export.ps1
@@ -17,17 +17,22 @@ Function Get-Folder($initialDirectory) {
     return $folder
 }
 
-# Spider and find each page, create directory for each group
+# Spider and find each page, create directory for each group, and build TOC HTML
 Function Spider-OneNote-Notebook {
-    param( $onenote, $node, $path )
+    param( $onenote, $node, $path, $notebookRoot )
+    $tocHtml = ""
     $previouslevel = 0
     $previousname = ""
     $grandparent = ""
     $parent = ""
+
     foreach($child in $node.ChildNodes) {
-        $child.name = ReplaceIllegal -text $child.name
+        $safeName = ReplaceIllegal -text $child.name
         $levelchange = $child.pageLevel - $previouslevel
+        $displayName = [System.Net.WebUtility]::HtmlEncode($child.name)
+
         if (-not $child.HasChildNodes) {
+            # --- It's a Page ---
             if ($levelchange -eq 1) {
                 if ($previouslevel -ne 0) {
                     $grandparent = $parent
@@ -35,37 +40,55 @@ Function Spider-OneNote-Notebook {
                 }
                 $filepath = Join-Path -path $(join-path -path $path -ChildPath $grandparent) -ChildPath $parent
                 New-Item -Path $filepath -ItemType directory -ErrorAction Ignore | Out-Null
-                Export-OneNote-Page -onenote $onenote -node $child -path $filepath
-
+                $fileAbsPath = Export-OneNote-Page -onenote $onenote -node $child -path $filepath
             } elseif ($levelchange -eq -1) {
                 $filepath = Join-Path -path $path -ChildPath $grandparent
                 New-Item -Path $filepath -ItemType directory -ErrorAction Ignore | Out-Null
-                Export-OneNote-Page -onenote $onenote -node $child -path $filepath
+                $fileAbsPath = Export-OneNote-Page -onenote $onenote -node $child -path $filepath
                 $parent = $grandparent
                 $grandparent = ""
             } elseif ($levelchange -eq -2) {
-                Export-OneNote-Page -onenote $onenote -node $child -path $path
+                $fileAbsPath = Export-OneNote-Page -onenote $onenote -node $child -path $path
                 $parent = ""
                 $grandparent = ""
             } elseif ($levelchange -eq 0 -and $parent -eq "") {
-                Export-OneNote-Page -onenote $onenote -node $child -path $path
+                $fileAbsPath = Export-OneNote-Page -onenote $onenote -node $child -path $path
             } else {
                 $grandparentpath = Join-Path -path $path -ChildPath $grandparent
                 $filepath = Join-Path -path $grandparentpath -ChildPath $parent
                 New-Item -Path $filepath -ItemType directory -ErrorAction Ignore | Out-Null
-                Export-OneNote-Page -onenote $onenote -node $child -path $filepath
+                $fileAbsPath = Export-OneNote-Page -onenote $onenote -node $child -path $filepath
             }
+            
+            # Create a relative link for the index.htm
+            if ($fileAbsPath) {
+                $relPath = $fileAbsPath.Substring($notebookRoot.Length + 1)
+                $relUrl = $relPath -replace '\\', '/' -replace ' ', '%20'
+                
+                # Use margin-left to visually indent subpages based on their OneNote level
+                $indentLevel = [int]$child.pageLevel * 20
+                $tocHtml += "<li class='page' style='margin-left: $($indentLevel)px;'><a href=`"$relUrl`">$displayName</a></li>`n"
+            }
+
         } else {
-            $folder = Join-Path -Path $path -ChildPath $child.name
+            # --- It's a Section or Section Group ---
+            $folder = Join-Path -Path $path -ChildPath $safeName
             New-Item -Path $folder -ItemType directory -ErrorAction Ignore | Out-Null
             Write-Host "  Section: $($folder)"
-            Spider-OneNote-Notebook -onenote $onenote -node $child -path $folder
-        }
-        # Store page level
-        $previouslevel = $child.pageLevel
-        $previousname = $child.name
-    }
 
+            $tocHtml += "<li class='section'>$displayName<ul>`n"
+            # Recursively crawl the section and append its HTML
+            $childToc = Spider-OneNote-Notebook -onenote $onenote -node $child -path $folder -notebookRoot $notebookRoot
+            $tocHtml += $childToc
+            $tocHtml += "</ul></li>`n"
+        }
+
+        # Store page level & name for next loop iteration
+        $previouslevel = $child.pageLevel
+        $previousname = $safeName 
+    }
+    
+    return $tocHtml
 }
 
 # Export page
@@ -75,17 +98,23 @@ Function Export-OneNote-Page {
     $name = ReplaceIllegal -text $node.name
     $file = $(Join-Path -Path $path -ChildPath "$($name).htm")
     Write-Host "    Page: $($file)"
+    
     # Export
     $onenote.Publish($node.ID, $file, 7, "")
-	$attachmentpath = Join-Path -Path $path -ChildPath ($child.Name + "_files")
+    
+    # [BUGFIX] Changed $child.Name to $name here so attachments export correctly
+	$attachmentpath = Join-Path -Path $path -ChildPath ($name + "_files")
     Export-OneNote-Attachments -onenote $onenote -node $node -path $attachmentpath
+
+    # Return the absolute path so the Spider function can link to it
+    return $file
 }
 
 # Copy embedded attachments
 Function Export-OneNote-Attachments {
     param ( $onenote, $node, $path )
     $xml = ''
-    $schema = @{one=”http://schemas.microsoft.com/office/onenote/2013/onenote”}
+    $schema = @{one="http://schemas.microsoft.com/office/onenote/2013/onenote"}
     $onenote.GetPageContent($node.ID, [ref]$xml)
     $xml | Select-Xml -XPath "//one:Page/one:Outline/one:OEChildren/one:OE/one:InsertedFile" -Namespace $schema | foreach {
         $file = Join-Path -Path $path -ChildPath $_.Node.preferredName
@@ -96,15 +125,22 @@ Function Export-OneNote-Attachments {
 
 Function ReplaceIllegal {
     param ( $text )
-    $illegal = [string]::join('',([System.IO.Path]::GetInvalidFileNameChars())) -replace '\\','\\'
+    $illegal = [string]::join('',([System.IO.Path]::GetInvalidFileNameChars())) -replace '\\\\','\\\\'
     $replaced = $text -replace "[$illegal]",'_'
     return $replaced
 }
 
+# ================= MAIN EXECUTION =================
+
 # Get export folder
 $folder = Get-Folder
 
-# Connect
+if (-not $folder) {
+    Write-Host "No folder selected. Exiting."
+    exit
+}
+
+# Connect to OneNote COM API
 $OneNote = New-Object -ComObject OneNote.Application
 [xml]$Hierarchy = ""
 $OneNote.GetHierarchy("", [Microsoft.Office.InterOp.OneNote.HierarchyScope]::hsPages, [ref]$Hierarchy)
@@ -114,9 +150,48 @@ foreach ($notebook in $Hierarchy.Notebooks.Notebook ) {
     $name = ReplaceIllegal -text $notebook.name
     $nf = Join-Path -Path $folder -ChildPath $name
     Write-Host "Notebook: $($nf)"
-    New-Item -Path $nf -ItemType directory | Out-Null
-    Spider-OneNote-Notebook -onenote $OneNote -node $notebook -path $nf
+    New-Item -Path $nf -ItemType directory -ErrorAction Ignore | Out-Null
+    
+    # Kick off the spidering and capture the generated HTML list
+    $tocBody = Spider-OneNote-Notebook -onenote $OneNote -node $notebook -path $nf -notebookRoot $nf
+
+    # Wrap the list in a clean, styled HTML document
+    $safeNotebookName = [System.Net.WebUtility]::HtmlEncode($notebook.name)
+    $indexHtml = @"
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>$safeNotebookName - Index</title>
+    <style>
+        body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; padding: 20px; background-color: #f3f2f1; }
+        .container { max-width: 900px; margin: 0 auto; background: white; padding: 30px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        h1 { color: #7719aa; border-bottom: 2px solid #7719aa; padding-bottom: 10px; }
+        ul { list-style-type: none; padding-left: 20px; }
+        li { margin: 6px 0; }
+        .section { font-size: 1.2em; font-weight: bold; margin-top: 20px; color: #333; }
+        .page { font-size: 1em; font-weight: normal; }
+        a { text-decoration: none; color: #0078d4; }
+        a:hover { text-decoration: underline; color: #004578; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>$safeNotebookName</h1>
+        <ul>
+            $tocBody
+        </ul>
+    </div>
+</body>
+</html>
+"@
+
+    # Save the index.htm at the root of the exported Notebook folder
+    $indexPath = Join-Path -Path $nf -ChildPath "index.htm"
+    Set-Content -Path $indexPath -Value $indexHtml -Encoding UTF8
+    Write-Host "  -> Created Table of Contents: $($indexPath)"
 }
 
 # Cleanup filelist.xml files
 Get-ChildItem -path $folder filelist.xml -Recurse | foreach { Remove-Item -Path $_.FullName }
+Write-Host "Export Complete!"


### PR DESCRIPTION
I tried your script for my own purposes and it works really well. However, I felt the only thing holding me back from
using it to archive all my notebooks in some way detached from Microsofts fangs was some usable way to navigate the
export. That's why I added a `index.htm` generation.

>Disclaimer: This was done completely using `Gemini 3.1 Pro Thinking`.

The code is tested and works fine for me.

### What changed:
1. **Dynamic HTML Generation:** `Spider-OneNote-Notebook` now acts as an HTML builder. As it recursively crawls Sections and Pages, it formats them into `<li>` elements using the exact order provided by the COM API.
2. **Relative Linking:** The script calculates the relative URI from the root folder of the Notebook to the exported `.htm` file. This means you can move the exported folder anywhere on your NixOS machine, and the `index.htm` links will not break.
3. **Visual Subpage Indentation:** Because subpages are natively tracked by OneNote using `pageLevel` (e.g., Level 1, Level 2, etc.), I applied a dynamic CSS `margin-left` to the HTML elements. Subpages will visually indent under their parent pages just like they do in the OneNote UI.
4. **Clean UI:** The generated `index.htm` includes basic CSS styling matching the OneNote purple aesthetic, making it highly readable for archival purposes. 
5. **Attachment Bug Fix:** Fixed the syntax error on line 64 of your original script where `$child.Name` was `null`, which would have caused attachments to save directly to the root path or fail. 
